### PR TITLE
Add `install` to config to disable autodiscovery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -667,7 +667,3 @@ FodyWeavers.xsd
 .dropbox
 .dropbox.attr
 .dropbox.cache
-
-### Project
-#  (DEV) link to config file
-/*.lnk

--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="PREFERRED_PROJECT_CODE_STYLE" value="Default" />
+  </state>
+</component>

--- a/fsactl/addons.py
+++ b/fsactl/addons.py
@@ -77,6 +77,7 @@ class Addons:
         print("\n\nDownloading...\n\n")
         for worker in self.workers:
             worker.download()
+        print("Download finished.")
 
     def install(self, force: bool = True) -> None:
         print("\n\nInstalling...\n\n")

--- a/fsactl/workers/git.py
+++ b/fsactl/workers/git.py
@@ -25,6 +25,8 @@ from typing import List
 from typing import Optional
 from typing import Set
 
+from jinja2 import Template
+
 from fsactl.handlers.git import Git
 from fsactl.typing import YAML
 
@@ -78,43 +80,61 @@ class GitWorker(Worker):
         print(f"{self.addon_path.name:72}", end="")
 
         # print(self)
-        copy_dir: Optional[Path] = self._find_dir_to_install()
+        try:
+            copy_dirs: List[Path] = [
+                Path(Template(d).render(addon_path=str(self.addon_path)))
+                for d in self.addon["install"]
+            ]
+        except KeyError:
+            copy_dirs = []
+
+        if not copy_dirs:
+            copy_dir: Optional[Path] = self._find_dir_to_install()
+            if copy_dir:
+                copy_dirs.append(copy_dir)
         # print(f"GitWorker.update(): {copy_dir=}")
 
-        if copy_dir is None:  # TODO: Do something, when None
+        if not copy_dirs:  # TODO: Do something, when None
             print("[ERROR]")
             return
-        # print(f"{copy_dir=}")
-        self.community_path = self.community_dir / copy_dir.name
-        # print(f"GitWorker.update(): {self.community_path=}")
 
-        if self.vcs.has_updated or not self.community_path.is_dir() or force:
-            shutil.rmtree(self.community_path, ignore_errors=True)
+        msg: str = "[SKIP ]"  # Message last printed. Can only be changed to OK
 
-            try:
-                # The git directory leaves behind linked files,
-                # that can not be deleted by rmtree.
-                # TODO: Maybe use the kernel.dll to unlink the file
-                # that fails on rmtree and unlink it (should be noted
-                # in 'e') and re-run the function.
-                shutil.copytree(
-                    copy_dir,
-                    self.community_path,
-                    ignore=self.__class__.IGNORE_COPY,
-                )
-            except FileExistsError:
-                # Should not happen, due to the prevention, that the git
-                # directory is beeing copied.
-                # Will happen, if copied manuelly.
-                # print(f"{self.addon_path=} -> {self.community_path}, {e=}")
-                # sys.exit(1)
-                print("[ERROR]")
-                raise FileExistsError(
-                    "Maybe there is a linked file that coud not be deleted."
-                )
-            print("[ OK  ]")
-            return
-        print("[SKIP ]")
+        for copy_dir in copy_dirs:
+            # print(f"{copy_dir=}")
+            community_path = self.community_dir / copy_dir.name
+            # print(f"GitWorker.update(): {self.community_path=}")
+
+            if self.vcs.has_updated or not community_path.is_dir() or force:
+                shutil.rmtree(community_path, ignore_errors=True)
+
+                try:
+                    # The git directory leaves behind linked files,
+                    # that can not be deleted by rmtree.
+                    # TODO: Maybe use the kernel.dll to unlink the file
+                    # that fails on rmtree and unlink it (should be noted
+                    # in 'e') and re-run the function.
+                    shutil.copytree(
+                        copy_dir,
+                        community_path,
+                        ignore=self.__class__.IGNORE_COPY,
+                    )
+                except FileExistsError:
+                    # Should not happen, due to the prevention, that the git
+                    # directory is beeing copied.
+                    # Will happen, if copied manuelly.
+                    # print(f"{self.addon_path=} ->
+                    #       {self.community_path}, {e=}"
+                    #      )
+                    # sys.exit(1)
+                    print("[ERROR]")
+                    raise FileExistsError(
+                        "Maybe there is a linked file that coud not be "
+                        "deleted."
+                    )
+                msg = "[ OK  ]"
+                continue
+        print(msg)
 
 
 # vim: set ft=python :

--- a/fsactl/workers/worker.py
+++ b/fsactl/workers/worker.py
@@ -55,7 +55,6 @@ class Worker:
         self.community_dir: Path = community_dir
 
         self.addon_path: Path
-        self.community_path: Path
 
     def download(self) -> None:
         raise NotImplementedError()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,6 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-# install   semver pyyaml jinja2
 python = "^3.9"
 semver = "^2.13.0"
 PyYaml = "^5.3.1"


### PR DESCRIPTION
Make it possible to disable autodiscovery by using the `install` keyword. Additionally this makes it possible to install multible addons from one `addon` (source)

```yaml
---
msfs:
  addon_dir: F:/MSFS-ADDONS
  community_dir: F:/MSFS/Community
  addons:
    - github: Working-Title-MSFS-Mods/fspackages
      install:
      - "{{ addon_path }}/build/workingtitle-g3000"
      - "{{ addon_path }}/build/workingtitle-g1000"
      - "{{ addon_path }}/build/workingtitle-aircraft-cj4"
      build:
      - path: "{{ addon_path }}"
        command: powershell.exe "Set-ExecutionPolicy Bypass -Scope Process -Force; .\build.ps1 workingtitle-project-g3000.xml"
      - path: "{{ addon_path }}"
        command: powershell.exe "Set-ExecutionPolicy Bypass -Scope Process -Force; .\build.ps1 workingtitle-project-g1000.xml"
      - path: "{{ addon_path }}"
        command: powershell.exe "Set-ExecutionPolicy Bypass -Scope Process -Force; .\build.ps1 workingtitle-project-cj4.xml"
```